### PR TITLE
BZ #1219053: Display all nodes on list with no params

### DIFF
--- a/ironicclient/osc/v1/baremetal.py
+++ b/ironicclient/osc/v1/baremetal.py
@@ -102,8 +102,10 @@ class ListBaremetal(lister.Lister):
                 parsed_args.limit)
         params['limit'] = parsed_args.limit
         params['marker'] = parsed_args.marker
-        params['associated'] = parsed_args.associated
-        params['maintenance'] = parsed_args.maintenance
+        if parsed_args.associated:
+            params['associated'] = parsed_args.associated
+        if parsed_args.maintenance:
+            params['maintenance'] = parsed_args.maintenance
 
         if parsed_args.detail:
             columns = tuple(res_fields.NODE_FIELD_LABELS)


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1219053

When no params were passed, the list was still being filtered because
of maintenence and associated being set to false. This will keep
those params from being passed unless true.
