### PR TITLE
BZ #1232313: Fail better if no authentication available

### DIFF
--- a/ironicclient/osc/plugin.py
+++ b/ironicclient/osc/plugin.py
@@ -59,6 +59,7 @@ def make_client(instance):
         http_log_debug=http_log_debug,
         timings=instance.timing,
         region_name=instance._region_name,
+        endpoint=instance.auth_ref.auth_url,
     )
 
     return client


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1232313

If an rc file has not been sourced, and no other authentication is
available, this will result in a better error message than was
previously given.

Change-Id: I06b05f350dd1a45affc2f99a4115515c2e924fb4
